### PR TITLE
fix external variable #566

### DIFF
--- a/mcsema/BC/Instruction.cpp
+++ b/mcsema/BC/Instruction.cpp
@@ -294,6 +294,9 @@ llvm::Value *InstructionLifter::GetAddress(const NativeXref *cfg_xref) {
       << std::hex << inst_ptr->pc << " to " << cfg_xref->target_ea << std::dec
       << " must be in a known segment.";
 
+  if (cfg_xref->externalVar) {
+    return LiftExternalEA(cfg_xref->externalVar, cfg_xref->target_ea);
+  }
   return LiftEA(cfg_xref->target_segment, cfg_xref->target_ea);
 }
 

--- a/mcsema/BC/Util.h
+++ b/mcsema/BC/Util.h
@@ -53,6 +53,7 @@ llvm::FunctionType *LiftedFunctionType(void);
 // Translate `ea` into an LLVM value that is an address that points into the
 // lifted segment associated with `seg`.
 llvm::Constant *LiftEA(const NativeSegment *seg, uint64_t ea);
+llvm::Constant *LiftExternalEA(const NativeExternalVariable *, uint64_t);
 
 }  // namespace mcsema
 

--- a/mcsema/CFG/CFG.h
+++ b/mcsema/CFG/CFG.h
@@ -129,6 +129,7 @@ struct NativeExternalFunction : public NativeFunction {
 // Global variable defined inside of the lifted binary.
 struct NativeVariable : public NativeObject {
   const NativeSegment *segment = nullptr;
+  const NativeExternalVariable *externalVariable = nullptr;
   mutable llvm::Constant *address = nullptr;
 };
 
@@ -158,6 +159,7 @@ struct NativeXref {
 
   const NativeVariable *var = nullptr;
   const NativeFunction *func = nullptr;
+  const NativeExternalVariable *externalVar = nullptr;
 };
 
 struct NativeBlob {
@@ -204,7 +206,7 @@ struct NativeModule {
       name_to_extern_func;
 
   // Represent global and external variables.
-  std::unordered_map<uint64_t, const NativeVariable *> ea_to_var;
+  std::unordered_map<uint64_t, NativeVariable *> ea_to_var;
   std::unordered_map<std::string, const NativeExternalVariable *>
       name_to_extern_var;
 

--- a/tools/mcsema_disass/ida7/disass.py
+++ b/tools/mcsema_disass/ida7/disass.py
@@ -57,6 +57,8 @@ def execute(args, command_args):
   script_cmd.append(args.os)
   script_cmd.append("--entrypoint")
   script_cmd.append(args.entrypoint)
+  script_cmd.append("--binary")
+  script_cmd.append(args.binary)
   script_cmd.extend(command_args)  # Extra, script-specific arguments.
 
   cmd = []


### PR DESCRIPTION
- Use `elftools` read `.dynsym` section and get external variable's size. (IDA may get the wrong size of external variable)

- Fix bug of issue #566  