### PR TITLE
Test suite hotfix

### DIFF
--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -400,10 +400,13 @@ class Runner:
             base_name = os.path.basename(name)
             actual = os.path.join(self.t_recompiled, base_name)
             expected = os.path.join(self.t_bin, base_name)
-            if not filecmp.cmp(expected, actual):
-                counterexample += 'Files do not match: ' + basename + '\n'
+            try:
+                if not filecmp.cmp(expected, actual):
+                    counterexample += 'Files do not match: ' + base_name + '\n'
+                    correct = correct and False
+            except FileNotFoundError as e:
+                counterexample += 'File {} not found/produced! '.format(base_name)
                 correct = correct and False
-
 
         result = result_data.RUN if correct else result_data.FAIL
         return (result, counterexample)

--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -520,6 +520,7 @@ g_complex_test = {
         TestDetails(['-l', './dec_data.txt.gz']).set_files(['inputs/dec_data.txt.gz']),
         TestDetails(['-df', './dec_data.txt.gz']).set_files(['inputs/dec_data.txt.gz']).\
                     set_check(['dec_data.txt']),
+        TestDetails(['']),
     ],
 
     "cat":

--- a/tests/integration_tests/src/all_data_array.c
+++ b/tests/integration_tests/src/all_data_array.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/all_globals.c
+++ b/tests/integration_tests/src/all_globals.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/all_stringpool.c
+++ b/tests/integration_tests/src/all_stringpool.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/all_switch.c
+++ b/tests/integration_tests/src/all_switch.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* TEST: 12 */
 /* TEST: 15 */
 /*

--- a/tests/integration_tests/src/array.c
+++ b/tests/integration_tests/src/array.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/bubblesort.c
+++ b/tests/integration_tests/src/bubblesort.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* TEST: 12 */
 /* TEST: 14 */
 /* TEST: 0 */

--- a/tests/integration_tests/src/calc.c
+++ b/tests/integration_tests/src/calc.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* TEST: */
 /* STDIN: Finputs/calc_input1.txt */
 /* TEST: */

--- a/tests/integration_tests/src/complex_double.c
+++ b/tests/integration_tests/src/complex_double.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* LD_OPTS: -lm */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.

--- a/tests/integration_tests/src/complex_float.c
+++ b/tests/integration_tests/src/complex_float.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* LD_OPTS: -lm */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.

--- a/tests/integration_tests/src/complex_long_double.c
+++ b/tests/integration_tests/src/complex_long_double.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* LD_OPTS: -lm */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.

--- a/tests/integration_tests/src/complex_numbers.c
+++ b/tests/integration_tests/src/complex_numbers.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* LD_OPTS: -lm */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.

--- a/tests/integration_tests/src/dot_product.c
+++ b/tests/integration_tests/src/dot_product.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/fibonacci.c
+++ b/tests/integration_tests/src/fibonacci.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* TEST: 12 */
 /* TEST: 26 */
 /* TEST: 2 */

--- a/tests/integration_tests/src/fmodf.cpp
+++ b/tests/integration_tests/src/fmodf.cpp
@@ -1,4 +1,6 @@
 /* TAGS: min cpp */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/global-ctors-dtors-return-type.c
+++ b/tests/integration_tests/src/global-ctors-dtors-return-type.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 #include <assert.h>
 #include <stdio.h>
 

--- a/tests/integration_tests/src/global-ctors-dtors.c
+++ b/tests/integration_tests/src/global-ctors-dtors.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 #include <assert.h>
 #include <stdio.h>
 

--- a/tests/integration_tests/src/global_array.c
+++ b/tests/integration_tests/src/global_array.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/global_var.cpp
+++ b/tests/integration_tests/src/global_var.cpp
@@ -1,4 +1,6 @@
 /* TAGS: min cpp */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2017 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/globals_and_io.c
+++ b/tests/integration_tests/src/globals_and_io.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/hello_c.c
+++ b/tests/integration_tests/src/hello_c.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2019 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/hello_cpp.cpp
+++ b/tests/integration_tests/src/hello_cpp.cpp
@@ -1,4 +1,6 @@
 /* TAGS: min cpp */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2019 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/helloworld.c
+++ b/tests/integration_tests/src/helloworld.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/iostream_basics.cpp
+++ b/tests/integration_tests/src/iostream_basics.cpp
@@ -1,4 +1,6 @@
 /* TAGS: min cpp */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/local-array.c
+++ b/tests/integration_tests/src/local-array.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/matrix_vector_mult.c
+++ b/tests/integration_tests/src/matrix_vector_mult.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 #include <stdio.h>
 
 static const int A [] = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };

--- a/tests/integration_tests/src/open_close_dir.c
+++ b/tests/integration_tests/src/open_close_dir.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* TEST: /usr */
 /* TEST: /eqeqeqwe */
 /*

--- a/tests/integration_tests/src/operator_new.cpp
+++ b/tests/integration_tests/src/operator_new.cpp
@@ -1,4 +1,6 @@
 /* TAGS: min cpp */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/pointers.c
+++ b/tests/integration_tests/src/pointers.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/printf_floats.cpp
+++ b/tests/integration_tests/src/printf_floats.cpp
@@ -1,4 +1,6 @@
 /* TAGS: min cpp */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/pthread.cpp
+++ b/tests/integration_tests/src/pthread.cpp
@@ -1,4 +1,6 @@
 /* TAGS: min cpp */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* LD_OPTS: -lpthread */
 /*
  * Copyright (c) 2017 Trail of Bits, Inc.

--- a/tests/integration_tests/src/qsort.c
+++ b/tests/integration_tests/src/qsort.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/qsort_function_ptrs.cpp
+++ b/tests/integration_tests/src/qsort_function_ptrs.cpp
@@ -1,4 +1,6 @@
 /* TAGS: min cpp */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* TEST: 23 */
 /* TEST: 43 */
 /* TEST: 435 */

--- a/tests/integration_tests/src/rand_and_strtol.c
+++ b/tests/integration_tests/src/rand_and_strtol.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/readdir.c
+++ b/tests/integration_tests/src/readdir.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* TEST: readdir.c */
 /* TEST: /tmp */
 /* TEST: file-that-does-not-exist */

--- a/tests/integration_tests/src/simple_array.c
+++ b/tests/integration_tests/src/simple_array.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/simple_exit.c
+++ b/tests/integration_tests/src/simple_exit.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/simple_for_loop.c
+++ b/tests/integration_tests/src/simple_for_loop.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/simple_main.c
+++ b/tests/integration_tests/src/simple_main.c
@@ -1,12 +1,6 @@
 /* TAGS: min c */
-/* CC_OPTS: */
-/* LD_OPTS: */
-/* LIFT_OPTS: EXP +explicit_args +explicit_args_count 8 !abi_libraries */
-/* TEST: --help */
-/* STDIN: F/inputs.txt */
-/* TEST: --version */
-/* TEST: --extract nonsense.txt */
-/* STDIN: Hello World\nThis Should Be Together */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/struct.c
+++ b/tests/integration_tests/src/struct.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/struct_func_ptr.cpp
+++ b/tests/integration_tests/src/struct_func_ptr.cpp
@@ -1,4 +1,6 @@
 /* TAGS: min cpp */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* TEST: */
 /* STDIN: 4\n4\n */
 /* TEST: */

--- a/tests/integration_tests/src/template_function_ptrs.cpp
+++ b/tests/integration_tests/src/template_function_ptrs.cpp
@@ -1,4 +1,6 @@
 /* TAGS: min cpp */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /* TEST: 42 */
 /* TEST: -543 */
 /* TEST: 21 */

--- a/tests/integration_tests/src/virtual.cpp
+++ b/tests/integration_tests/src/virtual.cpp
@@ -1,4 +1,6 @@
 /* TAGS: min cpp */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/virtual_simpler.cpp
+++ b/tests/integration_tests/src/virtual_simpler.cpp
@@ -1,4 +1,6 @@
 /* TAGS: min cpp */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *

--- a/tests/integration_tests/src/x86_bts.c
+++ b/tests/integration_tests/src/x86_bts.c
@@ -1,4 +1,6 @@
 /* TAGS: min c */
+/* LIFT_OPTS: explicit +--explicit_args +--explicit_args_count 8 */
+/* LIFT_OPTS: default */
 /*
  * Copyright (c) 2018 Trail of Bits, Inc.
  *


### PR DESCRIPTION
Some errors that popped up after removal of `unittest`, mostly related to not catching all relevant exceptions.