### PR TITLE
remove deprecated function `idc.GetTrueName(ea)` to support IDA7.4

### DIFF
--- a/tools/mcsema_disass/ida7/get_cfg.py
+++ b/tools/mcsema_disass/ida7/get_cfg.py
@@ -469,8 +469,10 @@ def is_start_of_function(ea):
   """Returns `True` if `ea` is the start of a function."""
   if not is_code(ea):
     return False
-
-  name = idc.GetTrueName(ea) or idc.get_func_name(ea)
+   
+  # originally name = idc.GetTrueName(ea) or idc.get_func_name(ea)
+  # removed since ida 7.4 not supported
+  name = idc.get_func_name(ea)
   return ea == idc.get_name_ea_simple(name)
 
 _REFERENCE_OPERAND_TYPE = {


### PR DESCRIPTION
In issues #614 , IDA 7.4 cannot recognize function `GetTrueName` and eventually resulting error:
```
'module' object has no attribute 'GetTrueName' error
```

The solution is fairly simple, remove `idc.GetTrueName(ea)` and IDA 7.4 can run correctly.