### PR TITLE
Migrate IDA7 backend to latest API

### DIFF
--- a/tools/mcsema_disass/ida7/segment.py
+++ b/tools/mcsema_disass/ida7/segment.py
@@ -145,7 +145,7 @@ def find_missing_strings_in_segment(seg_ea, seg_end_ea):
     # The references of variable are getting identified and converted
     # into string; avoid that
     if last_was_string and  is_reference(ea):
-      item_size = idc.ItemSize(ea)
+      item_size = idc.get_item_size(ea)
       next_ea = ea + item_size
       last_was_string = False
 
@@ -264,7 +264,7 @@ def find_missing_xrefs_in_segment(seg_ea, seg_end_ea, binary_is_pie):
     if not is_invalid_ea(target_ea) and 0 != (qword_data | dword_data):
       DEBUG("WARNING: Removing likely in-object reference from nearby {:x} to {:x}".format(
           ea, target_ea))
-      idaapi.do_unknown_range(ea, 4, idc.DOUNK_EXPAND)
+      idaapi.del_items(ea, 4, idc.DELIT_EXPAND)
 
     next_ea = ea + 4
 

--- a/tools/mcsema_disass/ida7/table.py
+++ b/tools/mcsema_disass/ida7/table.py
@@ -293,7 +293,8 @@ def get_ida_jump_table_reader(builder, si):
     builder.offset = si.elbase
     
     # Figure out if we need to subtract the offset instead of add it.
-    if (si.flags2 & idaapi.SWI2_SUBTRACT) == idaapi.SWI2_SUBTRACT:
+    SWI2_SUBTRACT = idaapi.SWI_SUBTRACT >> 16
+    if (si.flags & SWI2_SUBTRACT) == SWI2_SUBTRACT:
       builder.offset_mult = -1
 
     DEBUG("IDA inferred jump table offset: {:x}".format(builder.offset))


### PR DESCRIPTION
Several APIs in original IDA7 backend are deprecated(still IDA6+ version).

This fix adapts those change according to [SDK porting guide](https://www.hex-rays.com/products/ida/7.0/docs/api70_porting_guide.shtml)