### PR TITLE
cmake: Set c++ standard to c++17.

### DIFF
--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -51,11 +51,7 @@ macro(main)
   #
 
   # Globally set the required C++ standard
-  if(WIN32)
-    set(CMAKE_CXX_STANDARD 14)
-  else()
-    set(CMAKE_CXX_STANDARD 11)
-  endif()
+  set(CMAKE_CXX_STANDARD 17)
 
   set(CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
Update c++ standard to `C++17`.
Having modern c++ brings a lot of benefits to the codebase and it is not even that unreasonably new, as `C++20` is being implemented.
`CFG_format_update` and possibly other branches are already counting with this change. It is presented in separate PR so it can be easily found as a commit in master.