### PR TITLE
Update CommandLineReference.md

### DIFF
--- a/docs/CommandLineReference.md
+++ b/docs/CommandLineReference.md
@@ -16,7 +16,7 @@ Where:
 
 ## mcsema-lift
 
-Usage: mcsema-lift --arch _architecture_ --os _platform_ --cfg _cfg-path_ [--output _output-path_] [--libc_constructor _init-function_] [--libc_destructor _fini-function_]
+Usage: mcsema-lift-${version} --arch _architecture_ --os _platform_ --cfg _cfg-path_ [--output _output-path_] [--libc_constructor _init-function_] [--libc_destructor _fini-function_]
 
 Where:
 


### PR DESCRIPTION
mcsema-lift => mcsema-lift-${version}

when i build from source code. binary file name is mcsema-lift-4.0.
and command is mcsema-lift-4.0.
and i found "mcsema-lift-"+ version from 4  source codes.