### PR TITLE
Annotate lifted functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ add_executable(${MCSEMA_LIFT}
   mcsema/BC/External.cpp
   mcsema/BC/Function.cpp
   mcsema/BC/Instruction.cpp
+  mcsema/BC/Info.cpp
   mcsema/BC/Legacy.cpp
   mcsema/BC/Lift.cpp
   mcsema/BC/Optimize.cpp

--- a/mcsema/BC/Function.cpp
+++ b/mcsema/BC/Function.cpp
@@ -54,6 +54,7 @@
 #include "mcsema/BC/Callback.h"
 #include "mcsema/BC/Function.h"
 #include "mcsema/BC/Instruction.h"
+#include "mcsema/BC/Info.h"
 #include "mcsema/BC/Legacy.h"
 #include "mcsema/BC/Lift.h"
 #include "mcsema/BC/Optimize.h"
@@ -1015,7 +1016,10 @@ void DeclareLiftedFunctions(const NativeModule *cfg_module) {
       LOG(INFO)
           << "Already inserted function: " << func_name << ", skipping.";
     }
+
+    info::Set( { cfg_func->name, cfg_func->ea }, *lifted_func );
   }
+
 }
 
 using Calls_t = std::vector<llvm::CallSite>;

--- a/mcsema/BC/Info.cpp
+++ b/mcsema/BC/Info.cpp
@@ -24,19 +24,21 @@ namespace mcsema {
 namespace info {
 
 void Set(const Info &meta, llvm::Function &func) {
-  SetMetadata(func, Kinds::ea_kind, std::to_string(meta.ea));
-  SetMetadata(func, Kinds::name_kind, meta.name);
+  if (meta.ea)
+    SetMetadata(func, Kinds::ea_kind, std::to_string(*meta.ea));
+  if (meta.name)
+    SetMetadata(func, Kinds::name_kind, *meta.name);
 }
 
 Info Get(llvm::Function &func) {
   return { Name(func), EA(func) };
 }
 
-std::string Name(llvm::Function &func) {
+std::optional<std::string> Name(llvm::Function &func) {
   return GetMetadata(func, Kinds::name_kind);
 }
 
-uint64_t EA(llvm::Function &func) {
+std::optional<uint64_t> EA(llvm::Function &func) {
   auto as_str = GetMetadata(func, Kinds::ea_kind);
   if (as_str.empty()) {
     LOG(WARNING) << remill::LLVMThingToString(&func) << " does not have set "

--- a/mcsema/BC/Info.cpp
+++ b/mcsema/BC/Info.cpp
@@ -19,7 +19,9 @@
 
 #include <remill/BC/Util.h>
 
-namespace mcsema::info {
+// TODO(lukas): Nested declaration once C++17 is available
+namespace mcsema {
+namespace info {
 
 void Set(const Info &meta, llvm::Function &func) {
   SetMetadata(func, Kinds::ea_kind, std::to_string(meta.ea));
@@ -44,6 +46,7 @@ uint64_t EA(llvm::Function &func) {
   return stoul( as_str );
 }
 
-} // namespace mcsema::info
+} // namespace info
+} // namespace mcsema
 
 

--- a/mcsema/BC/Info.cpp
+++ b/mcsema/BC/Info.cpp
@@ -40,12 +40,10 @@ std::optional<std::string> Name(llvm::Function &func) {
 
 std::optional<uint64_t> EA(llvm::Function &func) {
   auto as_str = GetMetadata(func, Kinds::ea_kind);
-  if (as_str.empty()) {
-    LOG(WARNING) << remill::LLVMThingToString(&func) << " does not have set "
-                 << Kinds::ea_kind;
-    return 0xffffffff;
+  if (!as_str) {
+    return {};
   }
-  return stoul( as_str );
+  return { stoul(*as_str) };
 }
 
 } // namespace info

--- a/mcsema/BC/Info.cpp
+++ b/mcsema/BC/Info.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <mcsema/BC/Info.h>
+#include <mcsema/BC/Util.h>
+
+#include <remill/BC/Util.h>
+
+namespace mcsema::info {
+
+void Set(const Info &meta, llvm::Function &func) {
+  SetMetadata(func, Kinds::ea_kind, std::to_string(meta.ea));
+  SetMetadata(func, Kinds::name_kind, meta.name);
+}
+
+Info Get(llvm::Function &func) {
+  return { Name(func), EA(func) };
+}
+
+std::string Name(llvm::Function &func) {
+  return GetMetadata(func, Kinds::name_kind);
+}
+
+uint64_t EA(llvm::Function &func) {
+  auto as_str = GetMetadata(func, Kinds::ea_kind);
+  if (as_str.empty()) {
+    LOG(WARNING) << remill::LLVMThingToString(&func) << " does not have set "
+                 << Kinds::ea_kind;
+    return 0xffffffff;
+  }
+  return stoul( as_str );
+}
+
+} // namespace mcsema::info
+
+

--- a/mcsema/BC/Info.h
+++ b/mcsema/BC/Info.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <iostream>
+#include <optional>
 #include <string>
 
 namespace llvm {
@@ -32,12 +33,18 @@ struct Kinds {
 };
 
 struct Info {
-  std::string name;
-  uint64_t ea;
+  std::optional<std::string> name;
+  std::optional<uint64_t> ea;
 
   template<typename Stream>
   friend Stream &operator<<(Stream &os, const Info &info) {
-    os << "0x" << std::hex << info.ea << std::dec << ": " << info.name << std::endl;
+    if ( info.ea ) {
+      os << "0x" << std::hex << *info.ea << std::dec;
+    } else {
+      os << "(unknown)";
+    }
+
+    os << ": " << ((info.name) ? *info.name : "(unknown)") << std::endl;
     return os;
   }
 };
@@ -45,8 +52,8 @@ struct Info {
 void Set(const Info &meta, llvm::Function &func);
 Info Get(llvm::Function &func);
 
-std::string Name(llvm::Function &func);
-uint64_t EA(llvm::Function &func);
+std::optional<std::string> Name(llvm::Function &func);
+std::optional<uint64_t> EA(llvm::Function &func);
 
 } // namespace mcsema::info
 

--- a/mcsema/BC/Info.h
+++ b/mcsema/BC/Info.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <iostream>
+#include <string>
+
+namespace llvm {
+class Function;
+} // namespace llvm
+
+namespace mcsema::info {
+
+struct Kinds {
+  // TODO(lukas): std::string_view once c++17 is available
+  static constexpr char *ea_kind = "bin.ea";
+  static constexpr char *name_kind = "bin.name";
+};
+
+struct Info {
+  std::string name;
+  uint64_t ea;
+
+  template<typename Stream>
+  friend Stream &operator<<(Stream &os, const Info &info) {
+    os << "0x" << std::hex << info.ea << std::dec << ": " << info.name << std::endl;
+    return os;
+  }
+};
+
+void Set(const Info &meta, llvm::Function &func);
+Info Get(llvm::Function &func);
+
+std::string Name(llvm::Function &func);
+uint64_t EA(llvm::Function &func);
+
+} // namespace mcsema::info
+
+

--- a/mcsema/BC/Util.cpp
+++ b/mcsema/BC/Util.cpp
@@ -75,7 +75,7 @@ llvm::Constant *LiftEA(const NativeSegment *cfg_seg, uint64_t ea) {
 
 void SetMetadata(llvm::GlobalObject &go,
                  const std::string &kind, const std::string &val) {
-  if (go.hasMetadata(kind)) {
+  if (go.getMetadata(kind)) {
     LOG(WARNING) << remill::LLVMThingToString(&go) << " already has metadata of kind: "
                  << kind;
   }

--- a/mcsema/BC/Util.cpp
+++ b/mcsema/BC/Util.cpp
@@ -84,7 +84,7 @@ void SetMetadata(llvm::GlobalObject &go,
   go.setMetadata(kind, node);
 }
 
-std::string GetMetadata(llvm::GlobalObject &go, const std::string &kind) {
+MetaValue GetMetadata(llvm::GlobalObject &go, const std::string &kind) {
   auto node = go.getMetadata(kind);
   if (!node) {
     return {};
@@ -93,7 +93,7 @@ std::string GetMetadata(llvm::GlobalObject &go, const std::string &kind) {
   CHECK(node->getNumOperands() == 1)
     << "util::GetMetada does not support nodes with more than one operand";
 
-  return llvm::cast<llvm::MDString>(node->getOperand(0))->getString().str();
+  return { llvm::cast<llvm::MDString>(node->getOperand(0))->getString().str() };
 }
 
 

--- a/mcsema/BC/Util.cpp
+++ b/mcsema/BC/Util.cpp
@@ -93,7 +93,7 @@ std::string GetMetadata(llvm::GlobalObject &go, const std::string &kind) {
   CHECK(node->getNumOperands() == 1)
     << "util::GetMetada does not support nodes with more than one operand";
 
-  return llvm::cast<llvm::MDString>(node)->getString().str();
+  return llvm::cast<llvm::MDString>(node->getOperand(0))->getString().str();
 }
 
 

--- a/mcsema/BC/Util.cpp
+++ b/mcsema/BC/Util.cpp
@@ -73,4 +73,28 @@ llvm::Constant *LiftEA(const NativeSegment *cfg_seg, uint64_t ea) {
       llvm::ConstantInt::get(gWordType, offset));
 }
 
+void SetMetadata(llvm::GlobalObject &go,
+                 const std::string &kind, const std::string &val) {
+  if (go.hasMetadata(kind)) {
+    LOG(WARNING) << remill::LLVMThingToString(&go) << " already has metadata of kind: "
+                 << kind;
+  }
+  auto &ctx = go.getContext();
+  auto node = llvm::MDNode::get(ctx, llvm::MDString::get(ctx, val));
+  go.setMetadata(kind, node);
+}
+
+std::string GetMetadata(llvm::GlobalObject &go, const std::string &kind) {
+  auto node = go.getMetadata(kind);
+  if (!node) {
+    return {};
+  }
+
+  CHECK(node->getNumOperands() == 1)
+    << "util::GetMetada does not support nodes with more than one operand";
+
+  return llvm::cast<llvm::MDString>(node)->getString().str();
+}
+
+
 }  // namespace mcsema

--- a/mcsema/BC/Util.h
+++ b/mcsema/BC/Util.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 
 #include "mcsema/CFG/CFG.h"
 
@@ -44,6 +45,62 @@ extern std::shared_ptr<llvm::LLVMContext> gContext;
 extern llvm::IntegerType *gWordType;
 extern std::unique_ptr<llvm::Module> gModule;
 
+template <typename Self>
+struct LLVMConstants {
+
+  llvm::ConstantInt *i32(int32_t value) {
+    return GetConstantInt(value, 32);
+  }
+
+  llvm::ConstantInt *i64(int64_t value) {
+    return GetConstantInt(value, 64);
+  }
+
+  llvm::ConstantInt *GetConstantInt(int64_t value, int64_t size) {
+    return llvm::ConstantInt::get(
+        llvm::Type::getIntNTy(static_cast<Self &>(*this).context, size), value);
+  }
+
+  llvm::Type *i64_t() {
+    return llvm::Type::getInt64Ty(static_cast<Self &>(*this).context);
+  }
+
+  llvm::Type *i64_ptr_t() {
+    return llvm::Type::getInt64PtrTy(static_cast<Self &>(*this).context);
+  }
+
+  llvm::Type *i_n_ptr_t(uint64_t size) {
+    return llvm::Type::getIntNPtrTy(static_cast<Self &>(*this).context, size);
+  }
+
+  llvm::Type *i8_t() {
+    return llvm::Type::getInt8Ty(static_cast<Self &>(*this).context);
+  }
+
+  llvm::Type *i8P_ptr_t() {
+    return llvm::Type::getInt8PtrTy(static_cast<Self &>(*this).context);
+  }
+
+  llvm::Type *i_n_ty(uint64_t size) {
+    return llvm::Type::getIntNTy(static_cast<Self &>(*this).context, size);
+  }
+
+  llvm::Value *undef(llvm::Type *type) {
+    return llvm::UndefValue::get(type);
+  }
+
+  llvm::Type *ptr(llvm::Type *type, unsigned addr_space=0) {
+    return llvm::PointerType::get(type, addr_space);
+  }
+
+};
+
+template<typename Self>
+struct ModuleUtil {
+  llvm::Function &function(const std::string &name) {
+    return *static_cast<Self &>(*this).module.getFunction(name);
+  }
+};
 
 llvm::Value *GetConstantInt(unsigned size, uint64_t value);
 

--- a/mcsema/BC/Util.h
+++ b/mcsema/BC/Util.h
@@ -114,10 +114,10 @@ llvm::FunctionType *LiftedFunctionType(void);
 llvm::Constant *LiftEA(const NativeSegment *seg, uint64_t ea);
 
 template<typename Yield>
-void ForEachLifted( llvm::Module &_module, Yield yield ) {
+void ForEachLifted(llvm::Module &_module, Yield yield) {
   using funcs = std::vector<llvm::Function *>;
-  for (auto f : remill::GetFunctionsByOrigin<funcs, remill::LiftedFunction>(_module )) {
-    yield( f );
+  for (auto f : remill::GetFunctionsByOrigin<funcs, remill::LiftedFunction>(_module)) {
+    yield(f);
   }
 }
 

--- a/mcsema/BC/Util.h
+++ b/mcsema/BC/Util.h
@@ -79,7 +79,7 @@ struct LLVMConstants {
     return llvm::Type::getInt8Ty(static_cast<Self &>(*this).context);
   }
 
-  llvm::Type *i8P_ptr_t() {
+  llvm::Type *i8_ptr_t() {
     return llvm::Type::getInt8PtrTy(static_cast<Self &>(*this).context);
   }
 

--- a/mcsema/BC/Util.h
+++ b/mcsema/BC/Util.h
@@ -121,6 +121,9 @@ void ForEachLifted( llvm::Module &_module, Yield yield ) {
   }
 }
 
+void SetMetadata(llvm::GlobalObject &go, const std::string &kind, const std::string &val);
+std::string GetMetadata(llvm::GlobalObject &go, const std::string &kind);
+
 }  // namespace mcsema
 
 #endif  // MCSEMA_BC_UTIL_H_

--- a/mcsema/BC/Util.h
+++ b/mcsema/BC/Util.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <list>
+#include <optional>
 #include <vector>
 
 #include <llvm/IR/IRBuilder.h>
@@ -121,8 +122,10 @@ void ForEachLifted(llvm::Module &_module, Yield yield) {
   }
 }
 
+using MetaValue = std::optional<std::string>;
+
 void SetMetadata(llvm::GlobalObject &go, const std::string &kind, const std::string &val);
-std::string GetMetadata(llvm::GlobalObject &go, const std::string &kind);
+MetaValue GetMetadata(llvm::GlobalObject &go, const std::string &kind);
 
 }  // namespace mcsema
 

--- a/mcsema/BC/Util.h
+++ b/mcsema/BC/Util.h
@@ -26,6 +26,8 @@
 
 #include "mcsema/CFG/CFG.h"
 
+#include "remill/BC/Annotate.h"
+
 namespace llvm {
 
 class BasicBlock;
@@ -110,6 +112,14 @@ llvm::FunctionType *LiftedFunctionType(void);
 // Translate `ea` into an LLVM value that is an address that points into the
 // lifted segment associated with `seg`.
 llvm::Constant *LiftEA(const NativeSegment *seg, uint64_t ea);
+
+template<typename Yield>
+void ForEachLifted( llvm::Module &_module, Yield yield ) {
+  using funcs = std::vector<llvm::Function *>;
+  for (auto f : remill::GetFunctionsByOrigin<funcs, remill::LiftedFunction>(_module )) {
+    yield( f );
+  }
+}
 
 }  // namespace mcsema
 


### PR DESCRIPTION
There is always some extra info about functions from the binary that is represented in the bitcode, but in really clunky way. This PR adds code that allows add metadata to each lifted function declaration after lift. At the moment these are `name` and `ea` however it can be extended rather easily.

Some extra utility functionality is added to the `Util.h`. These CRTP classes do not follow the mcsema code convention, since they are providing llvm types|values and `i8(42)` resembles the classical C++ types and llvm types in `.ll` form.

(Re-opened since git history got messy in the last one)