### PR TITLE
Fix KeyError issue with AArch64 targets

### DIFF
--- a/tools/mcsema_disass/binja/cfg.py
+++ b/tools/mcsema_disass/binja/cfg.py
@@ -113,7 +113,7 @@ def recover_ext_func(bv, pb_mod, sym):
     # Assume cdecl if the type is unknown
     cconv = ftype.calling_convention
     if cconv is not None and cconv.name in BINJA_CCONV_TYPES:
-      pb_extfn.cc = BINJA_CCONV_TYPES[cconv]
+      pb_extfn.cc = BINJA_CCONV_TYPES[str(cconv)]
     else:
       pb_extfn.cc = CFG_pb2.ExternalFunction.CallerCleanup
 


### PR DESCRIPTION
The key look-up assumes proper string conversion to "cdecl" which appears to not be the case on the latest Binary Ninja development build, thus: `KeyError: <calling convention: aarch64 cdecl>` occurs. By coercing to a string, this issue is fixed.