### PR TITLE
Fixes one egregious bug in how we alias registers.

### DIFF
--- a/mcsema/BC/Optimize.cpp
+++ b/mcsema/BC/Optimize.cpp
@@ -1392,7 +1392,8 @@ static llvm::Value *TryGetRegAlias(llvm::Value *ptr, unsigned offset) {
   const auto elem_type = ptr_type->getPointerElementType();
 
   std::stringstream ss;
-  ss << reg->name << "_" << std::hex << reinterpret_cast<uintptr_t>(elem_type);
+  ss << reg->name << '_' << offset << '_'
+     << std::hex << reinterpret_cast<uintptr_t>(elem_type);
   auto alias_name = ss.str();
   SanitizeNameForLinking(alias_name);
 
@@ -1628,7 +1629,6 @@ void OptimizeModule(const NativeModule *cfg_module) {
   pm.doFinalization();
 
   remill::RemoveDeadStores(gArch.get(), gModule.get(), bb_func, slots);
-
 
   // If some of the restores are *not* dead, then we will have eliminated
   // some loads and subsequent uses (in the `__remill_restore.*` argument lists)

--- a/tools/mcsema_disass/ida7/flow.py
+++ b/tools/mcsema_disass/ida7/flow.py
@@ -52,6 +52,23 @@ def try_mark_as_function(address):
   idaapi.auto_wait()
   return True
 
+
+def is_start_of_function(ea):
+  """Returns `True` if `ea` is the start of a function."""
+  global _FUNC_HEAD_EAS
+
+  if ea in _FUNC_HEAD_EAS:
+    return True
+
+  if not is_code(ea):
+    return False
+
+  func = ida_funcs.get_func(ea)
+  if not func:
+    return False
+
+  return ea == func.start_ea
+
 def find_linear_terminator(ea, max_num=256):
   """Find the terminating instruction of a basic block, without actually
   associating the instructions with the block. This scans linearly until

--- a/tools/mcsema_disass/ida7/util.py
+++ b/tools/mcsema_disass/ida7/util.py
@@ -22,6 +22,7 @@ import struct
 import inspect
 import ida_ua
 import ida_bytes
+import ida_funcs
 import sys
 
 _DEBUG_FILE = None


### PR DESCRIPTION
What would happen is that AL/AH, DL/DH, etc. would all map to the same alias because their containing register and types would be the same. Modified register aliases to have the form <name>_<offset>_<type>. Also fixed an issue in mcsema-disass where the main function wouldn't be recognized as a function, and thus not lifted.