### PR TITLE
MacOS CI: Fix Python tool test with PYTHONPATH

### DIFF
--- a/.github/workflows/vcpkg_ci.yml
+++ b/.github/workflows/vcpkg_ci.yml
@@ -110,4 +110,8 @@ jobs:
         run: |
           # --help return non-zero and fails...
           mcsema-lift-${{ matrix.llvm }}.0 --version
-          mcsema-disass-2 --help
+          # TODO Might want to use virtualenv for this whole Python installation process
+          # Will need to be updated based on the Python2 version used during installation
+          PYTHONPATH=/usr/local/lib/python2.7/site-packages mcsema-disass-2 --help
+          # Will need to be updated based on the Python3 version used during installation
+          PYTHONPATH=/usr/local/lib/python3.9/site-packages mcsema-disass-3 --help


### PR DESCRIPTION
Seems the MacOS CI runners have changed some logic underneath us, so these smoketests were failing.