### PR TITLE
Remove Python2 from pushed Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Test final Docker image
       run: |
         docker run --rm docker.pkg.github.com/lifting-bits/mcsema/mcsema-llvm${{ matrix.llvm }}-ubuntu${{ matrix.ubuntu }}-amd64:latest --version
-        docker run --rm --entrypoint=mcsema-disass-2 docker.pkg.github.com/lifting-bits/mcsema/mcsema-llvm${{ matrix.llvm }}-ubuntu${{ matrix.ubuntu }}-amd64:latest --help
+        docker run --rm --entrypoint=mcsema-disass docker.pkg.github.com/lifting-bits/mcsema/mcsema-llvm${{ matrix.llvm }}-ubuntu${{ matrix.ubuntu }}-amd64:latest --help
     - name: Push Image for LLVM ${{ matrix.llvm }} on ${{ matrix.ubuntu }}
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: |


### PR DESCRIPTION
Had to rename the directory where the Python 3 module is installed so that we could hard-code the PYTHONPATH to it, e.g. `lib/python3.6` -> `lib/python3` on Ubuntu 18.04 with default Python version installed by `apt install python3` or `lib/python3.8` -> `lib/python3` for Ubuntu 20.04.

closes #730 