### PR TITLE
fix weak linking

### DIFF
--- a/mcsema/BC/Lift.cpp
+++ b/mcsema/BC/Lift.cpp
@@ -90,8 +90,9 @@ static void ExportFunctions(const NativeModule *cfg_module) {
 
         //    remill::TieFunctions(ep, gModule->getFunction(cfg_func->lifted_name));
         remill::Annotate<remill::EntrypointFunction>(ep);
-        if(ep->getLinkage() != llvm::GlobalValue::ExternalWeakLinkage)
+        if (ep->getLinkage() != llvm::GlobalValue::ExternalWeakLinkage) {
           ep->setLinkage(llvm::GlobalValue::ExternalLinkage);
+        }
         ep->setVisibility(llvm::GlobalValue::DefaultVisibility);
 
       } else {


### PR DESCRIPTION
ExportFunctions would override the weak linkage set before

Signed-off-by: Fabian Kilger <kilger@sec.in.tum.de>