### PR TITLE
Fixed "could not connect to display" error

### DIFF
--- a/tools/mcsema_disass/ida7/disass.py
+++ b/tools/mcsema_disass/ida7/disass.py
@@ -42,6 +42,7 @@ def execute(args, command_args):
   env["HOME"] = os.path.expanduser('~')
   env["IDA_PATH"] = os.path.dirname(args.disassembler)
   env["PYTHONPATH"] = os.path.dirname(ida_dir)
+  env["DISPLAY"] = ":0"
   if "SystemRoot" in os.environ:
     env["SystemRoot"] = os.environ["SystemRoot"]
 


### PR DESCRIPTION
This is a pertaining issue in Linux systems where the DISPLAY variable isn't forwarded.

The error which is fixed is; "QXcbConnection: Could not connect to display". Users before have raised issues on this [here](https://github.com/lifting-bits/mcsema/issues?q=QXcbConnection%3A+Could+not+connect+to+display)